### PR TITLE
feat: classifier discrimination, correction fitness, registry init (#20)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,22 @@ The standalone tool-factory MCP server has been absorbed into the LCARS repo at 
 - **Tool lifecycle:** Tools are subject to the same fitness tracking as corrections (candidate → standard → promoted). Unused tools get archived.
 - **Safety:** Stage → approve gate is mandatory (NoAutoDeployment invariant). Foundry proposes tools, user approves via MCP call.
 
+## v0.6.4 — Classifier Discrimination & Correction Fitness (shipped)
+
+Dashboard review at 31 days (1,662 responses, 288 sessions) revealed three issues:
+
+### Classifier improvement
+Ambiguous query type dominated at 55% of classifications, inflating a heterogeneous catch-all. Added two new categories (`directive`, `conversational`) and expanded `factual` and `diagnostic` patterns. Ambiguous rate drops to ~13% on representative prompts. Dict order adjusted so `directive` breaks ties against `factual` for "can you X" patterns.
+
+### Correction fitness recovery
+Correction fitness declined from 90% → 76% week-over-week, concentrated in `ambiguous` + low-severity density corrections (65.6% effective). Root cause: the generic density correction was too vague for the heterogeneous ambiguous bucket. Fix: suppress low-severity density corrections for `ambiguous`, `conversational`, and `directive` query types. High-severity density corrections still fire for all query types.
+
+### Tool registry initialization (#15, #18)
+`tool-registry.json` was never created because `discover.scan()` only fired at ~5% probability during PreCompact. Added one-time initialization: SessionStart now calls `discover.scan()` when the registry file doesn't exist. Subsequent sessions skip the scan.
+
+### Threshold overrides
+Added query-type-specific density thresholds: `conversational` (0.40), `directive` (0.50). These join existing overrides for `code` (0.50) and `diagnostic` (0.55). Global density threshold (0.60) unchanged.
+
 ### Hybrid scoring implementation
 
 Implement the architecture from `docs/hybrid-scoring-design.md`:

--- a/data/corrections.json
+++ b/data/corrections.json
@@ -1,5 +1,5 @@
 {
-  "version": 13,
+  "version": 19,
   "strategies": [
     {
       "drift": "filler",
@@ -62,6 +62,27 @@
       "severity": "low",
       "query": "*",
       "template": "[Prior: drift on {reasons}. Correct.]"
+    },
+    {
+      "drift": "density",
+      "severity": "low",
+      "query": "ambiguous",
+      "template": "",
+      "note": "Ambiguous is a heterogeneous catch-all. Low-severity density corrections have 65% fitness \u2014 suppress to reduce noise."
+    },
+    {
+      "drift": "density",
+      "severity": "low",
+      "query": "conversational",
+      "template": "",
+      "note": "Conversational turns (yes, thanks, follow-ups) have inherently variable density. No correction."
+    },
+    {
+      "drift": "density",
+      "severity": "low",
+      "query": "directive",
+      "template": "",
+      "note": "Task directives naturally vary in density. No correction at low severity."
     },
     {
       "drift": "filler",

--- a/data/thresholds.json
+++ b/data/thresholds.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "global": {
     "filler": 0,
     "preamble": 0,
@@ -11,6 +11,12 @@
     },
     "diagnostic": {
       "density": 0.55
+    },
+    "conversational": {
+      "density": 0.40
+    },
+    "directive": {
+      "density": 0.50
     }
   },
   "tool_fitness": {

--- a/lib/classify.py
+++ b/lib/classify.py
@@ -2,7 +2,8 @@
 """Deterministic query-type classifier.
 
 Classifies user prompts by structure and keywords. No LLM calls.
-Categories: factual, diagnostic, code, emotional, claim, ambiguous, meta.
+Categories: factual, diagnostic, code, emotional, claim, meta, directive,
+conversational, ambiguous (fallback).
 
 Hook mode (UserPromptSubmit): reads hook JSON from stdin, classifies prompt,
 writes classification to query-type.tmp for Stop hook to consume.
@@ -31,6 +32,8 @@ PATTERNS = {
         r"(?:not\s+working|broken|failing|error|bug|issue|problem|crash)",
         r"(?:what's\s+wrong|what\s+happened|how\s+to\s+fix|troubleshoot)",
         r"(?:doesn't\s+(?:work|compile|run|build|start|connect))",
+        r"(?:(?:getting|seeing|having)\s+(?:an?\s+)?(?:error|issue|problem|warning))",
+        r"(?:it\s+(?:keeps|just)\s+(?:failing|crashing|hanging|timing\s*out))",
     ],
     "claim": [
         r"(?:is\s+it\s+true|I\s+(?:heard|read|think|believe)\s+that)",
@@ -48,11 +51,27 @@ PATTERNS = {
         r"(?:tell\s+me\s+about\s+(?:yourself|your|this\s+(?:plugin|system)))",
         r"/\w+",  # slash commands
     ],
+    "directive": [
+        r"(?:^(?:do|run|deploy|review|check|update|set\s+up|configure|install|push|merge|rebase|commit)\b)",
+        r"(?:please\s+(?:do|run|help|check|look|find|update|fix|review|deploy|set\s+up|configure|install))",
+        r"(?:go\s+ahead|let's\s+(?:do|start|try|go))",
+        r"(?:can\s+you\s+(?:do|run|help|check|look|find|update|fix|review|deploy|set\s+up|configure|install))",
+        r"(?:(?:could|would)\s+you\s+(?:please\s+)?(?:do|run|help|check|look|find|update|fix|review|deploy))",
+    ],
     "factual": [
         r"(?:what\s+is|who\s+is|when\s+(?:did|was|is)|where\s+(?:is|are|was))",
         r"(?:how\s+(?:many|much|long|old|far|often))",
         r"(?:list\s+(?:the|all)|show\s+me|find\s+(?:the|all))",
         r"(?:look\s+up|search\s+for|check\s+(?:the|if|whether))",
+        r"(?:tell\s+me\s+about(?!\s+(?:yourself|your|this\s+(?:plugin|system))))",
+        r"(?:explain\s+(?:the|how|why|what))",
+        r"(?:describe\s+(?:the|how|what))",
+    ],
+    "conversational": [
+        r"(?:^(?:yes|no|ok|okay|sure|thanks|thank\s+you|got\s+it|makes\s+sense|sounds\s+good|perfect|agreed|exactly|right|correct|nope|nah)(?:\s|[.!,]|$))",
+        r"(?:^(?:and|but|also|what\s+about|how\s+about|actually)\b)",
+        r"(?:(?:thoughts|opinions?|ideas?)\s*\??\s*$)",
+        r"(?:(?:never\s*mind|forget\s+(?:it|that)|scratch\s+that))",
     ],
 }
 

--- a/lib/inject.py
+++ b/lib/inject.py
@@ -83,10 +83,12 @@ def main():
     if stats:
         parts.append(stats)
 
-    # Environment tools line for promoted discovered tools
+    # Environment tools: initialize registry on first run, then inject promoted tools
     try:
         import registry
         import discover
+        if not os.path.exists(registry.REGISTRY_FILE):
+            discover.scan()
         env_tools = [t for t in registry.list_by_provenance("discovered")
                      if t.get("status") == "active" and t.get("tier") == "promoted"]
         if env_tools:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -81,6 +81,10 @@ class TestQueryTypes:
     def test_factual_tell_me_about(self):
         assert classify("tell me about LCARS") == "factual"
 
+    def test_tell_me_about_system_is_meta(self):
+        """Negative lookahead: 'tell me about this system' → meta, not factual."""
+        assert classify("tell me about this system") == "meta"
+
     def test_factual_explain(self):
         assert classify("explain how hooks work") == "factual"
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -48,6 +48,51 @@ class TestQueryTypes:
     def test_meta_slash_command(self):
         assert classify("/help") == "meta"
 
+    def test_directive_deploy(self):
+        assert classify("deploy this to staging") == "directive"
+
+    def test_directive_can_you(self):
+        assert classify("can you check the logs") == "directive"
+
+    def test_directive_lets(self):
+        assert classify("let's do it") == "directive"
+
+    def test_directive_please(self):
+        assert classify("please review this PR") == "directive"
+
+    def test_conversational_yes(self):
+        assert classify("yes") == "conversational"
+
+    def test_conversational_sounds_good(self):
+        assert classify("sounds good") == "conversational"
+
+    def test_conversational_thanks(self):
+        assert classify("thanks") == "conversational"
+
+    def test_conversational_what_about(self):
+        assert classify("what about X?") == "conversational"
+
+    def test_conversational_never_mind(self):
+        assert classify("never mind") == "conversational"
+
+    def test_conversational_thoughts(self):
+        assert classify("thoughts?") == "conversational"
+
+    def test_factual_tell_me_about(self):
+        assert classify("tell me about LCARS") == "factual"
+
+    def test_factual_explain(self):
+        assert classify("explain how hooks work") == "factual"
+
+    def test_factual_describe(self):
+        assert classify("describe the architecture") == "factual"
+
+    def test_diagnostic_getting_error(self):
+        assert classify("I'm getting an error when I run tests") == "diagnostic"
+
+    def test_diagnostic_keeps_crashing(self):
+        assert classify("it keeps crashing") == "diagnostic"
+
     def test_ambiguous_fallback(self):
         assert classify("thoughts on this?") == "ambiguous"
 

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -86,6 +86,61 @@ class TestAnswerPositionCoverage:
         assert "preamble" in result["correction"].lower() or "answer" in result["correction"].lower()
 
 
+class TestNewQueryTypeThresholds:
+    def test_conversational_density_threshold(self, tmp_path, monkeypatch):
+        """Conversational threshold is 0.40. Density 0.45 should NOT drift."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.45}
+        result = detect(score, "conversational")
+        assert result is None
+
+    def test_directive_density_threshold(self, tmp_path, monkeypatch):
+        """Directive threshold is 0.50. Density 0.52 should NOT drift."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.52}
+        result = detect(score, "directive")
+        assert result is None
+
+    def test_ambiguous_low_density_suppressed(self, tmp_path, monkeypatch):
+        """Ambiguous + low density should return empty correction (suppressed)."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.58}
+        result = detect(score, "ambiguous")
+        assert result is not None
+        assert result["correction"] == ""
+
+    def test_conversational_low_density_suppressed(self, tmp_path, monkeypatch):
+        """Conversational + low density should return empty correction."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.38}
+        result = detect(score, "conversational")
+        assert result is not None
+        assert result["correction"] == ""
+
+    def test_directive_low_density_suppressed(self, tmp_path, monkeypatch):
+        """Directive + low density should return empty correction."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.48}
+        result = detect(score, "directive")
+        assert result is not None
+        assert result["correction"] == ""
+
+    def test_ambiguous_high_density_still_corrects(self, tmp_path, monkeypatch):
+        """Ambiguous + HIGH density drift should still correct."""
+        import thresholds
+        monkeypatch.setattr(thresholds, "_runtime_path", lambda: str(tmp_path / "thresholds.json"))
+        score = {"padding_count": 0, "answer_position": 0, "info_density": 0.45}
+        result = detect(score, "ambiguous")
+        assert result is not None
+        assert result["severity"] == "high"
+        assert result["correction"] != ""
+
+
 class TestCorrectionSelection:
     def test_filler_high_returns_template_with_placeholder(self):
         score = {"padding_count": 5, "answer_position": 0, "info_density": 0.70}

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -42,33 +42,34 @@ class TestContextAssembly:
 
 
 class TestRegistryInitialization:
-    def test_scan_runs_when_registry_missing(self, lcars_tmpdir, monkeypatch):
+    def _run_inject_main(self, monkeypatch, capsys):
+        """Run inject.main() with stdin mocked to provide hook JSON."""
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"source": "startup"})))
+        inject.main()
+        return capsys.readouterr()
+
+    def test_scan_runs_when_registry_missing(self, lcars_tmpdir, monkeypatch, capsys):
         """SessionStart triggers discover.scan() when tool-registry.json doesn't exist."""
         scan_called = []
         import discover
         monkeypatch.setattr(discover, "scan", lambda: scan_called.append(True) or {"found": 0, "new": 0, "removed": 0})
 
-        # Registry file should not exist
         assert not os.path.exists(registry.REGISTRY_FILE)
 
-        # Simulate the inject.main() logic for registry init
-        if not os.path.exists(registry.REGISTRY_FILE):
-            discover.scan()
+        self._run_inject_main(monkeypatch, capsys)
 
         assert len(scan_called) == 1
 
-    def test_scan_skipped_when_registry_exists(self, lcars_tmpdir, monkeypatch):
+    def test_scan_skipped_when_registry_exists(self, lcars_tmpdir, monkeypatch, capsys):
         """SessionStart does NOT trigger scan when tool-registry.json already exists."""
         scan_called = []
         import discover
         monkeypatch.setattr(discover, "scan", lambda: scan_called.append(True) or {"found": 0, "new": 0, "removed": 0})
 
-        # Create the registry file
         registry.save(registry._default_registry())
         assert os.path.exists(registry.REGISTRY_FILE)
 
-        # Simulate the inject.main() logic for registry init
-        if not os.path.exists(registry.REGISTRY_FILE):
-            discover.scan()
+        self._run_inject_main(monkeypatch, capsys)
 
         assert len(scan_called) == 0

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,9 +1,11 @@
-"""Tests for lib/inject.py — context assembly."""
+"""Tests for lib/inject.py — context assembly and registry initialization."""
 
 import json
+import os
 
 import inject
 import store
+import registry
 
 
 class TestContextAssembly:
@@ -37,3 +39,36 @@ class TestContextAssembly:
         """Fresh startup with no prior scores → no stats."""
         stats = inject.load_stats("startup")
         assert stats == ""
+
+
+class TestRegistryInitialization:
+    def test_scan_runs_when_registry_missing(self, lcars_tmpdir, monkeypatch):
+        """SessionStart triggers discover.scan() when tool-registry.json doesn't exist."""
+        scan_called = []
+        import discover
+        monkeypatch.setattr(discover, "scan", lambda: scan_called.append(True) or {"found": 0, "new": 0, "removed": 0})
+
+        # Registry file should not exist
+        assert not os.path.exists(registry.REGISTRY_FILE)
+
+        # Simulate the inject.main() logic for registry init
+        if not os.path.exists(registry.REGISTRY_FILE):
+            discover.scan()
+
+        assert len(scan_called) == 1
+
+    def test_scan_skipped_when_registry_exists(self, lcars_tmpdir, monkeypatch):
+        """SessionStart does NOT trigger scan when tool-registry.json already exists."""
+        scan_called = []
+        import discover
+        monkeypatch.setattr(discover, "scan", lambda: scan_called.append(True) or {"found": 0, "new": 0, "removed": 0})
+
+        # Create the registry file
+        registry.save(registry._default_registry())
+        assert os.path.exists(registry.REGISTRY_FILE)
+
+        # Simulate the inject.main() logic for registry init
+        if not os.path.exists(registry.REGISTRY_FILE):
+            discover.scan()
+
+        assert len(scan_called) == 0


### PR DESCRIPTION
Resolves #20

## Summary

- **Classifier**: Add `directive` and `conversational` categories, expand `factual` and `diagnostic` patterns. Ambiguous rate drops from ~55% to ~13%.
- **Corrections**: Suppress low-severity density corrections for `ambiguous`, `conversational`, and `directive` query types (65.6% fitness → suppressed). High-severity corrections still fire.
- **Thresholds**: Add density overrides for `conversational` (0.40) and `directive` (0.50). Bump to v2.
- **Registry**: SessionStart calls `discover.scan()` on first run when `tool-registry.json` doesn't exist.
- **Housekeeping**: Close #15 and #18 (already implemented), clear stale staged tool proposals, update ROADMAP.

## Files changed (8 files, +204/-5)

| File | Change |
|------|--------|
| `lib/classify.py` | Add directive, conversational categories; expand factual, diagnostic |
| `data/corrections.json` | 3 suppression strategies for low-severity density |
| `data/thresholds.json` | Query-type overrides for conversational, directive |
| `lib/inject.py` | One-time registry initialization via discover.scan() |
| `tests/test_classify.py` | 16 new tests for new categories |
| `tests/test_drift.py` | 6 new tests for threshold overrides and suppression |
| `tests/test_inject.py` | 2 new tests for registry initialization |
| `ROADMAP.md` | v0.6.4 section |

## Test plan

- [x] 211 tests passing (23 new, 0 regressions)
- [x] Classifier validated against 30 representative prompts
- [x] Correction suppression verified end-to-end
- [x] Registry init logic verified (scan when missing, skip when exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)